### PR TITLE
Suppress a note in R CMD --as-cran check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ exec_program("python3 -c 'from google.protobuf import descriptor_pb2'"
              OUTPUT_VARIABLE python3_protobuf_output) # swallow stderr
 if(${python3_protobuf} EQUAL "0")
 else()
-  message("To activate the Python tests: python3 -mpip install protobuf")
+  message("To activate the Python tests: python3 -m pip install protobuf")
 endif()
 
 if(BUILD_TESTING AND TEST_PROTOBUFS_PROTOC)


### PR DESCRIPTION
I am really sorry to troll around with such minor things, but I get a NOTE in "R CMD --as-cran check rolog" saying that -mpip is a non-portable compiler flag. The python command also works with the space between m and pip, so this does not make a difference.